### PR TITLE
Fixed setRides to avoid keeping wrong campuses rides in rides list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added root dashboard for multi campus
 * Added capacity to car model crud
 ### Fix
+* Fixed setRides to avoid keeping wrong campuses rides in rides list
 ## Version 1.4.6
 ### Features
 * Added loading animation and success message while creating or editing CRUD

--- a/pages/_campus/planificator/index.vue
+++ b/pages/_campus/planificator/index.vue
@@ -105,7 +105,9 @@ export default {
         end,
       );
       drivers.splice(0, 0, { name: 'Requêtes utilisateur', id: null, availabilities: [] });
-      await this.$store.dispatch('realtime/setRides', { campus: this.campus, start, end });
+      await this.$store.dispatch('realtime/setRides', {
+        campus: this.campus, start, end, persist: true,
+      });
       this.drivers = drivers;
     },
   },

--- a/store/realtime.js
+++ b/store/realtime.js
@@ -78,7 +78,9 @@ export const actions = {
       throw new Error('Drivers fetching failed');
     }
   },
-  async setRides({ commit, getters }, { campus, start, end }) {
+  async setRides({ commit, getters }, {
+    campus, start, end, persist = false,
+  }) {
     const EDITABLE_FIELDS = [
       'id',
       'start',
@@ -97,10 +99,10 @@ export const actions = {
       'luggage',
     ].join(',');
     const { data: rides } = await this.$api.rides(campus, EDITABLE_FIELDS).getRides(start, end);
-    if (getters.rides.length === 0 || rides.length === 0) {
-      commit('setRides', rides);
-    } else {
+    if (persist && getters.rides.length !== 0) {
       rides.forEach((r) => commit('pushRide', r));
+    } else {
+      commit('setRides', rides);
     }
   },
 };


### PR DESCRIPTION
Checklist

- [x] I've added a mention in CHANGELOG.md

With old logic, if previous campus add rides it would trigger `pushRide` instead of `setRides`. Looks like `pushRide` in here was useless because this action is only triggered on "page refresh" logic (change campus and change calendar view).
